### PR TITLE
Support latest versions of `eslint-plugin-jsdoc`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # eslint-config-env changelog
 
+## 24.0.0
+
+### Major
+
+- Dropped Node.js 12 to support [newer versions](https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v39.0.0) of [eslint-plugin-jsdoc](https://github.com/gajus/eslint-plugin-jsdoc).
+
 ## 23.0.2
 
 ### Patch

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-env",
-  "version": "23.0.2",
+  "version": "24.0.0",
   "description": "ESLint config optimized for authoring packages that adapts to the project environment.",
   "license": "MIT",
   "author": {

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "index.js"
   ],
   "engines": {
-    "node": "^12.20.0 || ^14.13.1 || >= 16.0.0"
+    "node": "^14.13.1 || >= 16.0.0"
   },
   "peerDependencies": {
     "eslint": "7.5 - 8",
     "eslint-plugin-import": "^2.21.0",
-    "eslint-plugin-jsdoc": "34 - 37",
+    "eslint-plugin-jsdoc": "^39.2.9",
     "eslint-plugin-node": "9 - 11"
   },
   "dependencies": {


### PR DESCRIPTION
Upstream breaking changes:

https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v39.0.0
- Dropped Node 12 support

https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v38.0.0
- **`match-description`**: `match-description` regular expressions now need to take account for trailing whitespace
